### PR TITLE
Add optional terminal

### DIFF
--- a/magiccube/cube_print.py
+++ b/magiccube/cube_print.py
@@ -4,7 +4,12 @@ from enum import Enum
 from magiccube.cube_base import Color, Face
 
 C_RESET = "\x1b[0;0m"
-# C_BG="\x1b[48;5;231m"
+C_GREEN = "\x1b[48;5;40m\x1b[38;5;232m"
+C_BLUE = "\x1b[48;5;21m\x1b[38;5;7m"
+C_RED = "\x1b[48;5;196m\x1b[38;5;232m"
+C_ORANGE = "\x1b[48;5;208m\x1b[38;5;232m"
+C_YELLOW = "\x1b[48;5;226m\x1b[38;5;232m"
+C_WHITE = "\x1b[48;5;248m\x1b[38;5;232m"
 
 
 class Terminal(Enum):
@@ -15,18 +20,21 @@ class Terminal(Enum):
 class CubePrintStr:
     """Prints a cube to stdout"""
     _xterm256_color_map = {
-        Color.G: "\x1b[48;5;40m\x1b[38;5;232m",
-        Color.B: "\x1b[48;5;21m\x1b[38;5;7m",
-        Color.R: "\x1b[48;5;196m\x1b[38;5;232m",
-        Color.O: "\x1b[48;5;208m\x1b[38;5;232m",
-        Color.Y: "\x1b[48;5;226m\x1b[38;5;232m",
-        Color.W: "\x1b[48;5;248m\x1b[38;5;232m",
+        Color.G: C_GREEN,
+        Color.B: C_BLUE,
+        Color.R: C_RED,
+        Color.O: C_ORANGE,
+        Color.Y: C_YELLOW,
+        Color.W: C_WHITE,
     }
 
-    def __init__(self, cube):
+    def __init__(self, cube, terminal: Terminal | None = None):
         self.cube = cube
-        self.term = Terminal.x256 if os.environ.get(
-            "TERM") == "xterm-256color" else Terminal.default
+        if terminal is not None:
+            self.term = terminal
+        else:
+            self.term = Terminal.x256 if os.environ.get(
+                "TERM") == "xterm-256color" else Terminal.default
 
     def _format_color(self, color: Color):
         """Format color to TTY
@@ -57,7 +65,7 @@ class CubePrintStr:
         "Print the cube to stdout"
         cube = self.cube
 
-        # flatten midle layer
+        # flatten middle layer
         print_order_mid = zip(cube.get_face(Face.L), cube.get_face(Face.F),
                               cube.get_face(Face.R), cube.get_face(Face.B))
 

--- a/test/test_cube.py
+++ b/test/test_cube.py
@@ -1,4 +1,6 @@
+import os
 import random
+from unittest import mock
 import pytest
 import numpy as np
 from magiccube import Cube
@@ -92,30 +94,16 @@ def test_is_done():
     assert c.is_done()
 
 
-def test_print_pattern1():
+def test_pattern1():
     c = Cube(3)
     c.rotate("R R L' L' B B F' F' U U D' D'")
     c.check_consistency()
-    print(c)
 
 
-def test_print_pattern2():
+def test_pattern2():
     c = Cube(3)
     c.rotate("R' L U D' F B' R' L")
     c.check_consistency()
-    print(c)
-
-
-def test_print_2d():
-    c = Cube(2)
-    c.check_consistency()
-    print(c)
-
-
-def test_print_4d():
-    c = Cube(4)
-    c.check_consistency()
-    print(c)
 
 
 def test_history_str():
@@ -154,21 +142,18 @@ def test_reverse_multiplicative_moves():
 def test_scramble_3x3():
     c = Cube(3)
     c.scramble(num_steps=50)
-    print(c)
     assert not c.is_done()
 
 
 def test_scramble_2x2():
     c = Cube(2)
     c.scramble(num_steps=50)
-    print(c)
     assert not c.is_done()
 
 
 def test_scramble_4x4():
     c = Cube(4)
     c.scramble(num_steps=50)
-    # print(c)
     assert not c.is_done()
 
 
@@ -259,14 +244,11 @@ def test_move_noloc():
 def test_move_outcome():
     c = Cube(3)
     c.rotate("B'")
-    print(c)
     assert c.get_piece((0, 2, 0)).get_piece_colors_str() == 'YOB'
     assert c.get_piece((0, 0, 0)).get_piece_colors_str() == 'YRB'
 
     c = Cube(3)
     c.rotate("F")
-    print(repr(c))
-    print(c)
     assert c.get_piece((2, 0, 2)).get_piece_colors_str() == 'WRG'
     assert c.get_piece((0, 0, 2)).get_piece_colors_str() == 'YRG'
 
@@ -296,21 +278,28 @@ def test_move_outcome():
 def test_find():
     c = Cube(3)
     c.rotate("R")
-    print(c)
     coord, _ = c.find_piece("GRW")
     assert coord == (2, 2, 0)
     coord, _ = c.find_piece("BOY")
     assert coord == (0, 0, 0)
 
 
+@mock.patch.dict(os.environ, {"TERM": "none"})
 def test_print_simple_move():
+
     c = Cube(3)
-    print(c)
-    print(repr(c))
-    print("XXXXXXXXXXXXXXXXXXXXXX")
     c.rotate("F")
-    print(repr(c))
-    print(c)
+
+    assert str(c) == \
+        "          W  W  W                   \n" + \
+        "          W  W  W                   \n" + \
+        "          O  O  O                   \n" + \
+        " O  O  Y  G  G  G  W  R  R  B  B  B \n" + \
+        " O  O  Y  G  G  G  W  R  R  B  B  B \n" + \
+        " O  O  Y  G  G  G  W  R  R  B  B  B \n" + \
+        "          R  R  R                   \n" + \
+        "          Y  Y  Y                   \n" + \
+        "          Y  Y  Y                   \n"
 
 
 def test_wide_move():
@@ -491,7 +480,6 @@ def test_rotate_twice():
     assert c.is_done()
 
     c.rotate("F2")
-    print(c.get_face_flat(Face.U))
     assert c.get_face_flat(Face.U) == [
         Color.W, Color.W, Color.W,
         Color.W, Color.W, Color.W,
@@ -501,7 +489,6 @@ def test_rotate_twice():
     assert c.is_done()
 
     c.rotate("B2")
-    print(c.get_face_flat(Face.U))
     assert c.get_face_flat(Face.U) == [
         Color.Y, Color.Y, Color.Y,
         Color.W, Color.W, Color.W,

--- a/test/test_cube_print.py
+++ b/test/test_cube_print.py
@@ -1,0 +1,36 @@
+from magiccube.cube import Cube
+from magiccube.cube_print import C_BLUE, C_GREEN, C_ORANGE, C_RED, C_RESET, C_WHITE, C_YELLOW, CubePrintStr, Terminal
+
+
+def test_print_2d():
+    c = Cube(2)
+    printer = CubePrintStr(c, terminal=Terminal.x256)
+    cube_str = printer.print_cube()
+    print(cube_str)
+    assert cube_str == \
+        f"      {C_WHITE} W {C_RESET}{C_WHITE} W {C_RESET}            \n" + \
+        f"      {C_WHITE} W {C_RESET}{C_WHITE} W {C_RESET}            \n" + \
+        f"{C_ORANGE} O {C_RESET}{C_ORANGE} O {C_RESET}" + \
+        f"{C_GREEN} G {C_RESET}{C_GREEN} G {C_RESET}" + \
+        f"{C_RED} R {C_RESET}{C_RED} R {C_RESET}" + \
+        f"{C_BLUE} B {C_RESET}{C_BLUE} B {C_RESET}\n" + \
+        f"{C_ORANGE} O {C_RESET}{C_ORANGE} O {C_RESET}" + \
+        f"{C_GREEN} G {C_RESET}{C_GREEN} G {C_RESET}" + \
+        f"{C_RED} R {C_RESET}{C_RED} R {C_RESET}" + \
+        f"{C_BLUE} B {C_RESET}{C_BLUE} B {C_RESET}\n" + \
+        f"      {C_YELLOW} Y {C_RESET}{C_YELLOW} Y {C_RESET}            \n" + \
+        f"      {C_YELLOW} Y {C_RESET}{C_YELLOW} Y {C_RESET}            \n"
+
+
+def test_print_2d_no_term():
+    c = Cube(2)
+    printer = CubePrintStr(c, terminal=Terminal.default)
+    cube_str = printer.print_cube()
+    print(cube_str)
+    assert cube_str == \
+        "       W  W             \n" + \
+        "       W  W             \n" + \
+        " O  O  G  G  R  R  B  B \n" + \
+        " O  O  G  G  R  R  B  B \n" + \
+        "       Y  Y             \n" + \
+        "       Y  Y             \n"


### PR DESCRIPTION
`CubePrintStr` uses the TERM environment variable to determine if if should print with xterm color codes or not.

## Solution

Add an optional terminal parameter to `CubePrintStr` to override the TERM environment variable.