### PR TITLE
Movements review

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ See [examples](https://github.com/trincaog/magiccube/tree/main/examples) folder.
 |Fw Fw'| Wide rotation of 2 layers.|
 |3Fw 3Fw' | Wide rotation of 3 layers.|
 |3F 3F' | Rotation of the 3rd layer.|
-|F2 F2' | 2x rotation.|
+|F2 F'2 | 2x rotation.|
 
 ## Cube Coordinates
 

--- a/magiccube/cube_move.py
+++ b/magiccube/cube_move.py
@@ -72,7 +72,7 @@ class CubeMove():
     __slots__ = ('type', 'is_reversed', 'wide', 'layer', 'count')
 
     regex_pattern = re.compile(
-        "^(?:([0-9]*)(([LRDUBF])([w]?)|([XYZMES]))([']?)([0-9]?))$")
+        "^(?:([0-9]*)(([LRDUBF])([w]?)|([XYZMES]))([']?)(2?))$")
 
     # pylint: disable=too-many-positional-arguments
     def __init__(self, move_type: CubeMoveType, is_reversed: bool = False, wide: bool = False, layer: int = 1, count: int = 1):
@@ -144,7 +144,8 @@ class CubeMove():
         wide = "w" if self.wide else ""
         reversed_move = "'" if self.is_reversed else ""
         count = "" if int(self.count) == 1 else int(self.count)
-        return f"{layer}{self.type.name}{wide}{reversed_move}{count}"
+        string = f"{layer}{self.type.name}{wide}{reversed_move}{count}"
+        return string.replace("'2", "2")
 
     def __repr__(self):
         return str(self)  # pragma: no cover

--- a/magiccube/cube_move.py
+++ b/magiccube/cube_move.py
@@ -35,11 +35,11 @@ class CubeMoveType(Enum):
             return CubeMoveType.B
         if move_str == "F":
             return CubeMoveType.F
-        if move_str == "X":
+        if move_str in ("X", 'x'):
             return CubeMoveType.X
-        if move_str == "Y":
+        if move_str in ("Y", 'y'):
             return CubeMoveType.Y
-        if move_str == "Z":
+        if move_str in ("Z", 'z'):
             return CubeMoveType.Z
         if move_str == "M":
             return CubeMoveType.M
@@ -72,7 +72,7 @@ class CubeMove():
     __slots__ = ('type', 'is_reversed', 'wide', 'layer', 'count')
 
     regex_pattern = re.compile(
-        "^(?:([0-9]*)(([LRDUBF])([w]?)|([XYZMES]))([']?)(2?))$")
+        "^(?:([0-9]*)(([LRDUBF])([w]?)|([xyzXYZMES]))([']?)(2?))$")
 
     # pylint: disable=too-many-positional-arguments
     def __init__(self, move_type: CubeMoveType, is_reversed: bool = False, wide: bool = False, layer: int = 1, count: int = 1):
@@ -86,11 +86,11 @@ class CubeMove():
     def _create_move(result, special_move):
         if special_move is not None:
             is_reversed = result[-2] == "'"
-            if special_move == "X":
+            if special_move in ("X", "x"):
                 return CubeMove(CubeMoveType.X, is_reversed)
-            if special_move == "Y":
+            if special_move in ("Y", "y"):
                 return CubeMove(CubeMoveType.Y, is_reversed)
-            if special_move == "Z":
+            if special_move in ("Z", "z"):
                 return CubeMove(CubeMoveType.Z, is_reversed)
             if special_move == "M":
                 return CubeMove(CubeMoveType.M, is_reversed)

--- a/test/test_cube.py
+++ b/test/test_cube.py
@@ -134,7 +134,7 @@ def test_reverse_multiplicative_moves():
     c = Cube(3)
     moves = "R' L2"
     c.rotate(moves)
-    assert c.reverse_history(to_str=True) == "L'2 R"
+    assert c.reverse_history(to_str=True) == "L2 R"
     c.rotate(c.reverse_history())
     assert c.is_done()
 

--- a/test/test_cube_move.py
+++ b/test/test_cube_move.py
@@ -47,3 +47,9 @@ def test_move_from_doc():
 
     with pytest.raises(CubeException):
         CubeMove.create("F2'")
+
+
+def test_reversed_double_corrected():
+    move = CubeMove.create("Z2")
+    assert str(move) == "Z2"
+    assert str(move.reverse()) == "Z2"

--- a/test/test_cube_move.py
+++ b/test/test_cube_move.py
@@ -20,6 +20,10 @@ def test_create_move():
     assert CubeMoveType.create("Y") == CubeMoveType.Y
     assert CubeMoveType.create("Z") == CubeMoveType.Z
 
+    assert CubeMoveType.create("x") == CubeMoveType.X
+    assert CubeMoveType.create("y") == CubeMoveType.Y
+    assert CubeMoveType.create("z") == CubeMoveType.Z
+
     with pytest.raises(CubeException):
         CubeMoveType.create("A")
 
@@ -38,6 +42,7 @@ def test_create_move_str():
 
 def test_move_eq():
     assert CubeMove.create("F") == CubeMove.create("F")
+    assert CubeMove.create("X") == CubeMove.create("x")
     assert CubeMove.create("B") != 1
 
 

--- a/test/test_cube_move.py
+++ b/test/test_cube_move.py
@@ -39,3 +39,11 @@ def test_create_move_str():
 def test_move_eq():
     assert CubeMove.create("F") == CubeMove.create("F")
     assert CubeMove.create("B") != 1
+
+
+def test_move_from_doc():
+    assert CubeMove.create("F2")
+    assert CubeMove.create("F'2")
+
+    with pytest.raises(CubeException):
+        CubeMove.create("F2'")


### PR DESCRIPTION
Hello,

While exploring magiccube and its movement notation, I identified several improvements:

- Fixed the README to better align with the code and tests
- Improved the __str__ representation for double anti-clockwise movements: changed from R'2 to R2
- Constrained move count to a maximum of 2
- Implemented x, y, z orientation moves according to SiGN notation standards
(https://www.speedsolving.com/wiki/index.php?title=SiGN_notation)

Best regards